### PR TITLE
Added glider airfield Fischbek to aerolist.php

### DIFF
--- a/flightlog/aerolist.php
+++ b/flightlog/aerolist.php
@@ -360,7 +360,8 @@ $aero = array (
 	'EPZP'=> array('ZIELONA GORA-PRZYLEP',"l.rec='EPZP' AND l.alt < 777 AND (l.lat BETWEEN 51.9745 AND 51.98353 ) AND (l.lon BETWEEN 15.44851 AND 15.47366)",77,''),
 	'LKZN'=> array('ZNOJMO',"l.rec='LKZN' AND l.alt < 952 AND (l.lat BETWEEN 48.81558 AND 48.82013 ) AND (l.lon BETWEEN 16.05637 AND 16.07446)",252,''),
 	'LKKR'=> array('KRNOV',"l.rec='LKKR' AND l.alt < 1074 AND (l.lat BETWEEN 50.07143 AND 50.0785 ) AND (l.lon BETWEEN 17.68805 AND 17.70232)",374,''),
-	'EBZR'=> array('ZOERSEL',"l.rec='EBZR' AND l.alt < 716 AND (l.lat BETWEEN 51.2511 AND 51.28014 ) AND (l.lon BETWEEN 4.72632 AND 4.78073)",16,'')
+	'EBZR'=> array('ZOERSEL',"l.rec='EBZR' AND l.alt < 716 AND (l.lat BETWEEN 51.2511 AND 51.28014 ) AND (l.lon BETWEEN 4.72632 AND 4.78073)",16,''),
+	'FISCHBEK'=> array('Fischbek',"l.rec='lmr33' AND l.alt < 700 AND (l.lat BETWEEN 53.4525 AND 53.4594 ) AND (l.lon BETWEEN 9.8230 AND 9.8395)",64,'')
 	);
 
 ?>


### PR DESCRIPTION
Added glider airfield Fischbek to aerolist.php. The airfield does not have an ICAO code so FISCHBEK was chosen as ID. Please consider the proposed addition, it would make writing flight logs a lot easier for my club.